### PR TITLE
Could not take photo

### DIFF
--- a/AppToolkit/AppToolkit/sources/public/CommandRequester.swift
+++ b/AppToolkit/AppToolkit/sources/public/CommandRequester.swift
@@ -883,8 +883,9 @@ public class CommandRequester: CommandRequesterInterface {
                                   distortion: Bool,
                                   completion: TakePhotoClosure?) -> TransactionID? {
                 
-                let closure: ((URIBasedInfo?, ErrorResponse?) -> ()) = { [weak self] (value, error) in
-                    guard let sself = self, let robot = sself.requester.connectionPolicyManager.currentRobot, let photo = value, let uri = photo.uri else {
+                let closure: ((URIBasedInfo?, ErrorResponse?) -> ()) = {  (value, error) in
+                     let sself = self
+                     guard let robot = sself.requester.connectionPolicyManager.currentRobot, let photo = value, let uri = photo.uri else {
                         completion?(nil, error)
                         return
                     }


### PR DESCRIPTION
"robot = sself.requester.connectionPolicyManager.currentRobot" is always nil and that is why it enters in the guard and executes the completion with nil